### PR TITLE
small fixes and changes

### DIFF
--- a/cudaup.packets
+++ b/cudaup.packets
@@ -1,8 +1,7 @@
 ATBinHex-Lazarus/atbinhex/atbinhex_package.lpk
-ATFlatControls/atflatcontrols/atflatcontrols_package.lpk 
+ATFlatControls/atflatcontrols/atflatcontrols_package.lpk
 ATSynEdit/atsynedit/atsynedit_package.lpk
-ATSynEdit_Ex/atsynedit_ex/atsynedit_ex_package.lpk 
 EControl/econtrol/econtrol_package.lpk
+ATSynEdit_Ex/atsynedit_ex/atsynedit_ex_package.lpk
 Python-for-Lazarus/python4lazarus/python4lazarus_package.lpk
 UniqueInstance/uniqueinstance/uniqueinstance_package.lpk
-

--- a/cudaup.repos
+++ b/cudaup.repos
@@ -2,7 +2,7 @@ https://github.com/Alexey-T/CudaText
 https://github.com/Alexey-T/ATBinHex-Lazarus
 https://github.com/Alexey-T/ATFlatControls
 https://github.com/Alexey-T/ATSynEdit
-https://github.com/Alexey-T/ATSynEdit_Ex
 https://github.com/Alexey-T/EControl
+https://github.com/Alexey-T/ATSynEdit_Ex
 https://github.com/Alexey-T/Python-for-Lazarus
 https://github.com/Alexey-T/UniqueInstance

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -20,8 +20,8 @@ Options:
   -h  --help                 show this message
 "
 
-OPTIONS=gpml:o:c:
-LONGOPTS=get,packs,make,lazdir:,os:,cpu:
+OPTIONS=hgpml:o:c:
+LONGOPTS=help,get,packs,make,lazdir:,os:,cpu:
 ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
 if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
 	echo "$usage"  

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -6,7 +6,7 @@ CPU="$HOSTTYPE"
 DoGet='false'
 DoInstallLibs='false'
 DoMake='false'
-lazdir=$(dirname "$(readlink -f "$(which lazbuild)")")
+lazdir=$(dirname "$(readlink -f "$(which lazbuild 2> /dev/null)")")
 usage="
 Usage: $(basename $0) [OPTION...]
 

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -20,6 +20,8 @@ Options:
   -h  --help                 show this message
 "
 
+[ $# -eq 0 ] && { echo "$usage"; exit 0; }
+
 OPTIONS=hgpml:o:c:
 LONGOPTS=help,get,packs,make,lazdir:,os:,cpu:
 ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -117,6 +117,13 @@ then
 	then
 		inc="$inc --cpu=$CPU"
 	fi
+	if [ $DoInstallLibs = 'false' ]
+	then
+		for i in $Packets
+		do
+			"$lazdir/lazbuild" $inc -q --lazarusdir="$lazdir" "./src/$i"
+		done
+	fi
 	"$lazdir/lazbuild" $inc -q --lazarusdir="$lazdir" "./src/CudaText/app/cudatext.lpi"
 	mkdir -pv "./bin/$OS-$CPU"
 	if [ $OS = 'win32' ] || [ $OS = 'win64' ]

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,27 @@
+Bash script to download all CudaText sources and build them.
+Working dir is ~/cudatext_up
+Build results are in subdir /bin
+
+Download + build for current platform:
+```shell
+./cudaup.sh -g -m
+```
+Download + build for current platform and install packages in Lazarus:
+```shell
+./cudaup.sh -g -p -m
+```
+Download + build for current platform, with custom path to Lazarus:
+```shell
+./cudaup.sh -g -m -l /path/to/lazarus
+```
+Download + cross-compile to another platform:
+```shell
+./cudaup.sh -g -m -l /path/to/lazarus -o system -c cpu
+```
+  
+Possible values of "system": win32, win64, linux, freebsd, darwin
+Possible values of "cpu" (not for win32, win64): i386, x86_64, arm
+To cross-compile to another platform, you need to use FpcUpDeluxe and install cross-compilers in its GUI.
+
+Author: @Artem3213212
+License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,14 @@ Bash script to download all CudaText sources and build them.
 Working dir is ~/cudatext_up
 Build results are in subdir /bin
 
-Download+build for current platform:
+Download + build for current platform:
+$ ./cudaup.sh -g -m
+Download + build for current platform and install packages in Lazarus:
 $ ./cudaup.sh -g -p -m
-Download+build for current platform, with custom path to Lazarus:
-$ ./cudaup.sh -g -p -m -l /path/to/lazarus
-Download+ cross-compile to another platform:
-$ ./cudaup.sh -g -p -m -l /path/to/lazarus -o system -c cpu
+Download + build for current platform, with custom path to Lazarus:
+$ ./cudaup.sh -g -m -l /path/to/lazarus
+Download + cross-compile to another platform:
+$ ./cudaup.sh -g -m -l /path/to/lazarus -o system -c cpu
   
 Possible values of "system": win32, win64, linux, freebsd, darwin
 Possible values of "cpu" (not for win32, win64): i386, x86_64, arm


### PR DESCRIPTION
1. Добавил поддержку сборки без установки пакетов в Lazarus, так как lazbuild не требует их установки.
2. Исправил -h|--help.
3. Убрал предупреждение which, если lazbuild не найден в PATH.
4. Обновил справку для первого коммита.
5. atsynedit_ex зависит от econtrol. Исправил очерёдность сборки пакетов.
6. Если запустить cudaup.sh без параметров, показать справку и выйти.