### PR TITLE
Add gitignore to ignore build related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# ignore files created by build process
+bin/
+src/


### PR DESCRIPTION
After build is complete git sees the output files (in bin, src directories) as changes which is a potential problem for devs. This PR adds a .gitignore to ignore build related files so that future commits can be done without thinking that much about ignoring build files.