### PR TITLE
Do a shallow git clone instead of a full clone

### DIFF
--- a/cudaup.sh
+++ b/cudaup.sh
@@ -116,7 +116,7 @@ then
 	do	
 		temp=${i/'https://github.com/Alexey-T/'/''}
 		temp=${temp/'https://github.com/bgrabitmap/'/''}
-		[ ! -d "$temp/.git" ] && git clone "$i"	
+		[ ! -d "$temp/.git" ] && git clone --depth 1 "$i"	
 		cd "$temp"
 		git pull origin master
 		cd ../


### PR DESCRIPTION
`git clone --depth 1 ...` causes it to clone only the last commit and a single branch which saves a lot of time and disk space when building. For building, we don't need full history and other branches anyway (at least as much as I tested).

For time, it can save minutes. For space, it saves megabytes:

```
$ du -hs src_*
308M	src_full
211M	src_shallow
```