### PR TITLE
Maintain shallow clone when git pull-ing

### DIFF
--- a/cudaup.sh
+++ b/cudaup.sh
@@ -116,13 +116,16 @@ then
 	do	
 		temp=${i/'https://github.com/Alexey-T/'/''}
 		temp=${temp/'https://github.com/bgrabitmap/'/''}
-		[ ! -d "$temp/.git" ] && git clone --depth 1 "$i"	
-		cd "$temp"
-		git pull --depth 1 --rebase origin master
-		git tag -d $(git tag -l)
-		git reflog expire --expire=all --all
-		git gc --prune=all
-		cd ../
+		if [ ! -d "$temp/.git" ]; then
+			git clone --depth 1 "$i"	
+		else
+			cd "$temp"
+			git pull --depth 1 --rebase origin master
+			git tag -d $(git tag -l)
+			git reflog expire --expire=all --all
+			git gc --prune=all
+			cd ../
+		fi
 	done
 	cd ../
 fi

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -118,7 +118,10 @@ then
 		temp=${temp/'https://github.com/bgrabitmap/'/''}
 		[ ! -d "$temp/.git" ] && git clone --depth 1 "$i"	
 		cd "$temp"
-		git pull origin master
+		git pull --depth 1 --rebase origin master
+		git tag -d $(git tag -l)
+		git reflog expire --expire=all --all
+		git gc --prune=all
 		cd ../
 	done
 	cd ../

--- a/cudaup.sh
+++ b/cudaup.sh
@@ -120,10 +120,14 @@ then
 			git clone --depth 1 "$i"	
 		else
 			cd "$temp"
+			last_commit="$(git log -n 1 --pretty=format:'%H')"
 			git pull --depth 1 --rebase origin master
-			git tag -d $(git tag -l)
-			git reflog expire --expire=all --all
-			git gc --prune=all
+			if [ "$last_commit" != "$(git log -n 1 --pretty=format:'%H')" ]; then
+				# There are new commits, so make size smaller like a new shallow clone
+				git tag -d $(git tag -l)
+				git reflog expire --expire=all --all
+				git gc --prune=all
+			fi
 			cd ../
 		fi
 	done


### PR DESCRIPTION
This maintains shallow clone status when updating already cloned git repos by previous build attempts. This should keep size smaller (and have a single latest commit) as expected, similar to a new shallow clone.

As posted in [this comment](https://github.com/Alexey-T/CudaText_up/pull/16#issuecomment-1260086354) before.

**NOTE:** I haven't tested it yet!! Just posting so that it can be discussed or tested. Especially if the commands work for everyone. Also I'm not sure if `--rebase` would be a safe option here. It helped me update a very old repo once without any error messages so I included it here. Feel free to test with older cloned dependency repos!