### PR TITLE
fix building for macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 Bash script to download all CudaText sources and build them.
-Working dir is ~/cudatext_up.
-Build results are in subdir /bin.
+Working dir is current directory.
+Build results are in subdir "./bin", or "src/CudaText/app/cudatext.app/Contents/MacOS/" for macOS.
 You need to clone the whole repository to use the script.
 
 Download + build for current platform:
@@ -22,7 +22,6 @@ Download + cross-compile to another platform:
   
 * Possible values of "system": win32, win64, linux, darwin, freebsd, openbsd, netbsd, dragonfly, solaris, haiku.
 * Possible values of "cpu" (not for win32, win64): i386, x86_64, arm, aarch64, sparc.
-* Better run script via "sudo", otherwise new folders will have mode rw-r--r-- and resulting CudaText binary cannot create its config settings/user.json
 
 To cross-compile to another platform, you need to use FpcUpDeluxe and install cross-compilers in its GUI.
 


### PR DESCRIPTION
1. BSD getopt isn't compatible with Linux getopt.
2. Lazarus.app isn't in PATH by default.
3. Permission 0777 and sudo shouldn't be used, there must be some real cause if errors happened.
4. wrong syntax for '$OS'.
5. always create ./src/CudaText/app/cudatext.app/Contents/MacOS because OS is linux by default.
6. fix readme about working dir and build results, on macOS cudaText must be started from .../Contents/MacOS to copy resources.